### PR TITLE
Add sponsors section and update navigation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -170,7 +170,7 @@ color: #FFFFFF;
 }
 .navbar.navbar-default .navbar-brand {
   height: auto;
-  padding: 15px 10px;
+  padding: 15px 10px 15px 0;
 }
 .navbar.navbar-default .navbar-brand img {
   max-height: 50px;
@@ -1132,13 +1132,6 @@ width: 31px;
 text-align: center;
 }
 #footer ul > li img.social-icon {
-  width: 24px;
-  height: 24px;
-}
-#header li.nav-instagram {
-  display: inline-block;
-}
-#header li.nav-instagram img.header-icon {
   width: 24px;
   height: 24px;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -170,7 +170,10 @@ color: #FFFFFF;
 }
 .navbar.navbar-default .navbar-brand {
   height: auto;
-  padding: 22px 15px 21px;
+  padding: 15px 10px;
+}
+.navbar.navbar-default .navbar-brand img {
+  max-height: 50px;
 }
 .navbar-default .navbar-nav>li>a:hover, .navbar-default .navbar-nav>li>a:focus{
 color: #FFFFFF;
@@ -1129,6 +1132,13 @@ width: 31px;
 text-align: center;
 }
 #footer ul > li img.social-icon {
+  width: 24px;
+  height: 24px;
+}
+#header li.nav-instagram {
+  display: inline-block;
+}
+#header li.nav-instagram img.header-icon {
   width: 24px;
   height: 24px;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -15,6 +15,9 @@ body {
   line-height: 26px;
   overflow-x: hidden;
 }
+html {
+  overflow-x: hidden;
+}
 h1,
 h2,
 h3,
@@ -1143,6 +1146,9 @@ text-align: center;
   background: #f5f5f5;
   padding: 60px 0;
   text-align: center;
+}
+#commanditaires .section-header {
+  text-align: left;
 }
 #commanditaires .sponsor-logo {
   max-width: 150px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -13,6 +13,7 @@ body {
   font-weight: 400;
   color: #282828;
   line-height: 26px;
+  overflow-x: hidden;
 }
 h1,
 h2,
@@ -1117,12 +1118,16 @@ width: 100px;
   margin: 0 -7.5px;
 }
 #footer ul > li {
- display: inline-block; 
+ display: inline-block;
 
  border: 1px solid rgba(255, 255, 255, 0.09);
 padding: 3px 0;
 width: 31px;
 text-align: center;
+}
+#footer ul > li img.social-icon {
+  width: 24px;
+  height: 24px;
 }
 @media only screen and (min-width: 768px) {
   #footer .social-icons {
@@ -1132,6 +1137,16 @@ text-align: center;
 .form-control {
   box-shadow: none;
   -webkit-box-shadow: none;
+}
+
+#commanditaires {
+  background: #f5f5f5;
+  padding: 60px 0;
+  text-align: center;
+}
+#commanditaires .sponsor-logo {
+  max-width: 150px;
+  margin: 15px auto;
 }
 @media only screen and (max-width: 480px) {
 #hero-banner {

--- a/icebox2025.html
+++ b/icebox2025.html
@@ -30,8 +30,9 @@
                      <li class="scroll"><a href="#stats">Statistiques</a></li>
                      <li><a href="index.html#commanditaires">Commanditaires</a></li>
                      <li class="scroll"><a href="#contact">Contact</a></li>
-                  </ul>
-               </div>
+                     <li class="nav-instagram"><a href="https://www.instagram.com/iceboxmtl" target="_blank"><img class="header-icon" src="https://about.meta.com/brand/static/instagram/instagram-brand/Instagram_Glyph_Gradient.png" alt="Instagram"></a></li>
+                 </ul>
+              </div>
             </div>
          </nav>
       </header>

--- a/icebox2025.html
+++ b/icebox2025.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="fr">
+   <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>ICE BOX Challenge Montreal 2025 - Club Habitek</title>
+      <link href="css/bootstrap.min.css" rel="stylesheet">
+      <link href="css/font-awesome.min.css" rel="stylesheet">
+      <link href="css/animate.min.css" rel="stylesheet">
+      <link href="css/prettyPhoto.css" rel="stylesheet">
+      <link href="css/styles.css" rel="stylesheet">
+      <link rel="shortcut icon" href="images/ico/favicon.ico">
+   </head>
+   <body id="home">
+      <header id="header">
+         <nav id="main-nav" class="navbar navbar-default navbar-fixed-top" role="banner">
+            <div class="container">
+               <div class="navbar-header">
+                  <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                  <span class="sr-only">Basculer la navigation</span>
+                  <span class="icon-bar"></span>
+                  <span class="icon-bar"></span>
+                  <span class="icon-bar"></span>
+                  </button>
+                  <a class="navbar-brand" href="index.html"><img src="logo2.png" alt="logo"></a>
+               </div>
+               <div class="collapse navbar-collapse navbar-right">
+                  <ul class="nav navbar-nav">
+                     <li><a href="index.html">Accueil</a></li>
+                     <li class="scroll"><a href="#stats">Statistiques</a></li>
+                     <li><a href="index.html#commanditaires">Commanditaires</a></li>
+                     <li class="scroll"><a href="#contact">Contact</a></li>
+                  </ul>
+               </div>
+            </div>
+         </nav>
+      </header>
+
+      <section id="hero-banner">
+         <div class="banner-inner">
+            <div class="container">
+               <div class="row">
+                  <div class="col-sm-12">
+                     <div class="banner-text wow fadeInUp">
+                        <h2 class="section-title">ICE BOX Challenge Montreal 2025</h2>
+                        <p>Suivez l'innovation en efficacité énergétique.</p>
+                     </div>
+                  </div>
+               </div>
+            </div>
+         </div>
+      </section>
+
+      <section id="competition-info">
+         <div class="container">
+            <div class="section-header">
+               <h2 class="section-title wow fadeInDown">ICE-BOX Challenge</h2>
+            </div>
+            <div class="row">
+               <div class="features">
+                  <div class="col-md-12 col-sm-12 wow fadeInUp" data-wow-duration="300ms" data-wow-delay="0ms">
+                     <div class="media service-box">
+                        <div class="pull-left">
+                           <img src="icebox_challenge_logo.png"  alt="logo">
+                        </div>
+                        <div class="media-body">
+                           <h4 class="media-heading">ICE-BOX Challenge - Du 10 juillet au 31 juillet</h4>
+                           <p>Une compétition invitant la communauté universitaire à construire une enveloppe permettant de conserver une tonne de glace au frais en plein été sans système de refroidissement.</p>
+                           <p>Ce projet met en avant notre capacité à innover tout en répondant aux enjeux actuels du secteur, comme la réduction de la consommation énergétique et l’amélioration des performances thermiques des bâtiments.</p>
+                        </div>
+                     </div>
+                  </div>
+               </div>
+            </div>
+         </div>
+      </section>
+
+      <section id="stats">
+         <div class="container">
+            <div class="section-header">
+               <h2 class="section-title wow fadeInDown">Statistiques de l'enveloppe</h2>
+            </div>
+            <div class="row">
+               <div class="col-sm-6">
+                  <div class="house-card">
+                     <h3>Maison écoénergétique</h3>
+                     <p>Température extérieure: <span id="temp-ext-eco" class="stat-value">-- °C</span></p>
+                     <p>Humidité extérieure: <span id="hum-ext-eco" class="stat-value">-- %</span></p>
+                     <p>Température intérieure: <span id="temp-int-eco" class="stat-value">-- °C</span></p>
+                     <p>Humidité intérieure: <span id="hum-int-eco" class="stat-value">-- %</span></p>
+                  </div>
+               </div>
+               <div class="col-sm-6">
+                  <div class="house-card">
+                     <h3>Maison Code</h3>
+                     <p>Température extérieure: <span id="temp-ext-code" class="stat-value">-- °C</span></p>
+                     <p>Humidité extérieure: <span id="hum-ext-code" class="stat-value">-- %</span></p>
+                     <p>Température intérieure: <span id="temp-int-code" class="stat-value">-- °C</span></p>
+                     <p>Humidité intérieure: <span id="hum-int-code" class="stat-value">-- %</span></p>
+                  </div>
+               </div>
+            </div>
+         </div>
+      </section>
+
+      <section id="contact">
+         <div class="container contact-info">
+            <div class="row">
+               <div class="col-sm-4 col-md-4">
+                  <address>
+                     <strong>Club Habitek</strong><br>
+                     ÉTS, Montréal<br>
+                     Courriel : <a href="mailto:habitek@etsmtl.ca">habitek@etsmtl.ca</a>
+                  </address>
+               </div>
+               <div class="col-sm-8 col-md-8">
+                  <div class="contact-form">
+                     <form id="main-contact-form" method="post" action="#">
+                        <div class="form-group">
+                           <input type="text" name="name" class="form-control" placeholder="Nom" required>
+                        </div>
+                        <div class="form-group">
+                           <input type="email" name="email" class="form-control" placeholder="Courriel" required>
+                        </div>
+                        <div class="form-group">
+                           <input type="text" name="subject" class="form-control" placeholder="Sujet" required>
+                        </div>
+                        <div class="form-group">
+                           <textarea name="message" class="form-control" rows="8" placeholder="Message" required></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Envoyer</button>
+                     </form>
+                  </div>
+               </div>
+            </div>
+         </div>
+      </section>
+
+      <footer id="footer">
+         <div class="container">
+            <div class="row">
+               <div class="col-sm-6">
+                  &copy; 2025 Club Habitek. Tous droits réservés.
+               </div>
+               <div class="col-sm-6">
+                  <ul class="social-icons">
+                     <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174848.png" alt="Facebook" /></a></li>
+                     <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="Instagram" /></a></li>
+                     <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/145/145807.png" alt="LinkedIn" /></a></li>
+                  </ul>
+               </div>
+            </div>
+         </div>
+      </footer>
+
+      <script src="js/jquery.js"></script>
+      <script src="js/bootstrap.min.js"></script>
+      <script src="js/mousescroll.js"></script>
+      <script src="js/smoothscroll.js"></script>
+      <script src="js/jquery.prettyPhoto.js"></script>
+      <script src="js/jquery.isotope.min.js"></script>
+      <script src="js/jquery.inview.min.js"></script>
+      <script src="js/wow.min.js"></script>
+      <script src="js/custom-scripts.js"></script>
+   </body>
+</html>

--- a/icebox2025.html
+++ b/icebox2025.html
@@ -30,7 +30,6 @@
                      <li class="scroll"><a href="#stats">Statistiques</a></li>
                      <li><a href="index.html#commanditaires">Commanditaires</a></li>
                      <li class="scroll"><a href="#contact">Contact</a></li>
-                     <li class="nav-instagram"><a href="https://www.instagram.com/iceboxmtl" target="_blank"><img class="header-icon" src="https://about.meta.com/brand/static/instagram/instagram-brand/Instagram_Glyph_Gradient.png" alt="Instagram"></a></li>
                  </ul>
               </div>
             </div>

--- a/icebox2025.html
+++ b/icebox2025.html
@@ -64,7 +64,7 @@
                            <img src="icebox_challenge_logo.png"  alt="logo">
                         </div>
                         <div class="media-body">
-                           <h4 class="media-heading">ICE-BOX Challenge - Du 10 juillet au 31 juillet</h4>
+                           <h4 class="media-heading">ICE-BOX Challenge - Du 10 juillet au 29 juillet</h4>
                            <p>Une compétition invitant la communauté universitaire à construire une enveloppe permettant de conserver une tonne de glace au frais en plein été sans système de refroidissement.</p>
                            <p>Ce projet met en avant notre capacité à innover tout en répondant aux enjeux actuels du secteur, comme la réduction de la consommation énergétique et l’amélioration des performances thermiques des bâtiments.</p>
                         </div>
@@ -145,9 +145,9 @@
                <div class="col-sm-6">
                   <ul class="social-icons">
                      <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174848.png" alt="Facebook" /></a></li>
-                     <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="Instagram" /></a></li>
                      <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/145/145807.png" alt="LinkedIn" /></a></li>
-                  </ul>
+                     <li><a href="https://www.instagram.com/iceboxmtl"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="Instagram" /></a></li>
+                 </ul>
                </div>
             </div>
          </div>

--- a/index.html
+++ b/index.html
@@ -37,9 +37,10 @@
                      <li class="scroll"><a href="#portfolio">Le Projet</a></li>
                      <li class="scroll"><a href="#commanditaires">Commanditaires</a></li>
                      <li class="scroll"><a href="#contact">Contact</a></li>
-                  </ul>
-               </div>
-            </div>
+                     <li class="nav-instagram"><a href="https://www.instagram.com/iceboxmtl" target="_blank"><img class="header-icon" src="https://about.meta.com/brand/static/instagram/instagram-brand/Instagram_Glyph_Gradient.png" alt="Instagram"></a></li>
+                 </ul>
+              </div>
+           </div>
          </nav>
       </header>
       <section id="hero-banner">

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
                            <img src="icebox_challenge_logo.png"  alt="logo">
                         </div>
                         <div class="media-body">
-                           <h4 class="media-heading">ICE-BOX Challenge - Du 10 juillet au 31 juillet </h4>
+                           <h4 class="media-heading">ICE-BOX Challenge - Du 10 juillet au 29 juillet </h4>
                            <p> Une compétition invitant la communauté universitaire à construire une enveloppe permettant de conserver une tonne de glace au frais en plein été sans système de refroidissement.</p>
 							<p>
 							Ce projet met en avant notre capacité à innover tout en répondant aux enjeux actuels du secteur, comme la réduction de la consommation énergétique et l’amélioration des performances thermiques des bâtiments.
@@ -286,7 +286,7 @@
         </section>
         <section id="commanditaires">
                 <div class="container">
-                        <div class="section-header">
+                        <div class="section-header text-left">
                                 <h2 class="section-title wow fadeInDown">Nos commanditaires</h2>
                         </div>
                         <div class="row text-center">
@@ -415,9 +415,9 @@
                <div class="col-sm-6">
                   <ul class="social-icons">
                      <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174848.png" alt="Facebook" /></a></li>
-                     <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="Instagram" /></a></li>
                      <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/145/145807.png" alt="LinkedIn" /></a></li>
-                 </ul>
+                     <li><a href="https://www.instagram.com/iceboxmtl"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="Instagram" /></a></li>
+                </ul>
               </div>
             </div>
          </div>

--- a/index.html
+++ b/index.html
@@ -33,8 +33,9 @@
                      <li class="scroll"><a href="#about">Club Habitek</a></li>
                      <li class="scroll"><a href="#competitions">Compétition</a></li>
                      <li class="scroll"><a href="#team">L'équipe</a></li>
-                     <li class="scroll"><a href="#stats">Statistiques</a></li>
+                     <li><a href="icebox2025.html#stats">Statistiques</a></li>
                      <li class="scroll"><a href="#portfolio">Le Projet</a></li>
+                     <li class="scroll"><a href="#commanditaires">Commanditaires</a></li>
                      <li class="scroll"><a href="#contact">Contact</a></li>
                   </ul>
                </div>
@@ -265,33 +266,7 @@
    </div>
 </section>
 
-<section id="stats">
-   <div class="container">
-      <div class="section-header">
-         <h2 class="section-title wow fadeInDown">Statistiques de l'enveloppe</h2>
-      </div>
-      <div class="row">
-         <div class="col-sm-6">
-            <div class="house-card">
-               <h3>Maison écoénergétique</h3>
-               <p>Température extérieure: <span id="temp-ext-eco" class="stat-value">-- °C</span></p>
-               <p>Humidité extérieure: <span id="hum-ext-eco" class="stat-value">-- %</span></p>
-               <p>Température intérieure: <span id="temp-int-eco" class="stat-value">-- °C</span></p>
-               <p>Humidité intérieure: <span id="hum-int-eco" class="stat-value">-- %</span></p>
-            </div>
-         </div>
-         <div class="col-sm-6">
-            <div class="house-card">
-               <h3>Maison Code</h3>
-               <p>Température extérieure: <span id="temp-ext-code" class="stat-value">-- °C</span></p>
-               <p>Humidité extérieure: <span id="hum-ext-code" class="stat-value">-- %</span></p>
-               <p>Température intérieure: <span id="temp-int-code" class="stat-value">-- °C</span></p>
-               <p>Humidité intérieure: <span id="hum-int-code" class="stat-value">-- %</span></p>
-            </div>
-         </div>
-      </div>
-   </div>
-</section>
+
 
 
      
@@ -308,8 +283,29 @@
                                 
                 </div>
 		</div>
-	</section>
-	<section id="formulaire">
+        </section>
+        <section id="commanditaires">
+                <div class="container">
+                        <div class="section-header">
+                                <h2 class="section-title wow fadeInDown">Nos commanditaires</h2>
+                        </div>
+                        <div class="row text-center">
+                                <div class="col-xs-6 col-sm-3 wow fadeInUp" data-wow-delay="0s">
+                                        <img class="sponsor-logo" src="https://logo.clearbit.com/microsoft.com" alt="Microsoft">
+                                </div>
+                                <div class="col-xs-6 col-sm-3 wow fadeInUp" data-wow-delay="0.1s">
+                                        <img class="sponsor-logo" src="https://logo.clearbit.com/google.com" alt="Google">
+                                </div>
+                                <div class="col-xs-6 col-sm-3 wow fadeInUp" data-wow-delay="0.2s">
+                                        <img class="sponsor-logo" src="https://logo.clearbit.com/amazon.com" alt="Amazon">
+                                </div>
+                                <div class="col-xs-6 col-sm-3 wow fadeInUp" data-wow-delay="0.3s">
+                                        <img class="sponsor-logo" src="https://logo.clearbit.com/apple.com" alt="Apple">
+                                </div>
+                        </div>
+                </div>
+        </section>
+        <section id="formulaire">
 	 
 		<div class="container">
 			<div class="section-header">
@@ -418,11 +414,11 @@
                </div>
                <div class="col-sm-6">
                   <ul class="social-icons">
-                     <li><a href="#"><i class="fa fa-facebook"></i></a></li>
-                     <li><a href="#"><i class="fa fa-linkedin"></i></a></li>
-                     <li><a href="#"><i class="fa fa-linkedin"></i></a></li>
-                  </ul>
-               </div>
+                     <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174848.png" alt="Facebook" /></a></li>
+                     <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="Instagram" /></a></li>
+                     <li><a href="#"><img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/145/145807.png" alt="LinkedIn" /></a></li>
+                 </ul>
+              </div>
             </div>
          </div>
       </footer>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@
                      <li class="scroll"><a href="#portfolio">Le Projet</a></li>
                      <li class="scroll"><a href="#commanditaires">Commanditaires</a></li>
                      <li class="scroll"><a href="#contact">Contact</a></li>
-                     <li class="nav-instagram"><a href="https://www.instagram.com/iceboxmtl" target="_blank"><img class="header-icon" src="https://about.meta.com/brand/static/instagram/instagram-brand/Instagram_Glyph_Gradient.png" alt="Instagram"></a></li>
                  </ul>
               </div>
            </div>


### PR DESCRIPTION
## Summary
- add Commanditaires section with sponsor logos
- link to the new section from the main menu and mobile hamburger menu
- link to Commanditaires from the ICE BOX page
- style sponsor logos and background

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c77ca45c8832aabeaf5075bd5c611